### PR TITLE
Escape environment strings so they are valid in JSON.

### DIFF
--- a/java/src/com/ibm/javametrics/dataproviders/DataProviderManager.java
+++ b/java/src/com/ibm/javametrics/dataproviders/DataProviderManager.java
@@ -33,6 +33,10 @@ public class DataProviderManager {
 
     private ScheduledExecutorService exec;
 
+    private static String escapeStringForJSON(String str) {
+        return str.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
     /**
      * Create a JavametricsMBeanConnector
      */
@@ -55,13 +59,16 @@ public class DataProviderManager {
     private void emitEnvironmentData() {
         String paramFormat = "{\"Parameter\":\"%s\",\"Value\":\"%s\"}";
         StringBuilder message = new StringBuilder("[");
-        message.append(String.format(paramFormat, "Hostname", EnvironmentDataProvider.getHostname()));
+        message.append(String.format(paramFormat, "Hostname",
+                escapeStringForJSON(EnvironmentDataProvider.getHostname())));
         message.append(',');
-        message.append(String.format(paramFormat, "OS Architecture", EnvironmentDataProvider.getArchitecture()));
+        message.append(String.format(paramFormat, "OS Architecture",
+                escapeStringForJSON(EnvironmentDataProvider.getArchitecture())));
         message.append(',');
         message.append(String.format(paramFormat, "Number of Processors", EnvironmentDataProvider.getCPUCount()));
         message.append(',');
-        message.append(String.format(paramFormat, "Command Line", EnvironmentDataProvider.getCommandLine()));
+        message.append(String.format(paramFormat, "Command Line",
+                escapeStringForJSON(EnvironmentDataProvider.getCommandLine())));
         message.append("]");
         Javametrics.getInstance().sendJSON(ENV_TOPIC, message.toString());
     }


### PR DESCRIPTION
This escapes all the strings the environment parser returns so they are valid JSON.
The hostname is unlikely to contain special characters but the path and possibly the architecture string might contain `/` or `"`.

This is for issue #16 