### PR TITLE
Add prometheus support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The Application Metrics for Java agent requires Java version 8.
 Download the latest Application Metrics for Java release from [Github](http://github.com/runtimetools/javametrics/releases).
 This contains:
 * `javametrics-dash-x.x.x.war` - Javametrics Web Application
+* `javametrics-prometheus-x.x.x.war` - Javametrics Prometheus Endpoint
 * `javametrics-agent-x.x.x.jar` - Javametrics agent
 
 ### Building with Maven
@@ -59,10 +60,16 @@ javametrics-dash
 
  <groupId>com.ibm.runtimetools</groupId>
  <artifactId>javametrics-dash</artifactId>
+
+javametrics-prometheus
+ <groupId>com.ibm.runtimetools</groupId>
+ <artifactId>javametrics-prometheus</artifactId>
 ```
 
 #### Websphere Liberty
-Unpack the `.zip` or `.tar.gz` archive that you downloaded in the previous step.  Copy the `javametrics.war` file into your [Websphere Liberty](https://developer.ibm.com/wasdev/websphere-liberty/) 'dropins' directory.
+Unpack the `.zip` or `.tar.gz` archive that you downloaded in the previous step.  Copy the `javametrics-dash-x.x.x.war` and the `javametrics-prometheus-x.x.x.war` files into your [Websphere Liberty](https://developer.ibm.com/wasdev/websphere-liberty/) 'dropins' directory.
+
+If you only want the dashboard or prometheus support you can just copy the appropriate war file to the 'dropins' directory. Both require the agent to be loaded following the instructions below.
 
 Javametrics requires a Java option to be set in order to load the agent.  A [jvm.options](https://www.ibm.com/support/knowledgecenter/en/SSAW57_liberty/com.ibm.websphere.wlp.nd.multiplatform.doc/ae/twlp_admin_customvars.html) file is the best way to configure this for Websphere Liberty. It should contain the following entry, where `path_to_install_dir` is replaced with the actual path containing the javametrics file:
 
@@ -80,6 +87,8 @@ e.g.
 
 The URL for the dashboard consists of the server's default HTTP endpoint plus '/javametrics-dash'.  E.g. Running locally it might be: http://localhost:9080/javametrics-dash/
 
+The URL for the prometheus endpoint consists of the server's default HTTP endpoint plus the default prometheus metrics path `/metrics`.  E.g. Running locally it might be: http://localhost:9080/metrics/
+
 #### Spring
 Coming soon
 
@@ -92,13 +101,6 @@ Coming soon
 - [API Documentation](API-DOCUMENTATION.md)
 
 <a name="building"></a>
-
-## Building the jar and war files from source
-
-Requirements: Maven
-
-To build javametrics, run `mvn clean package` from the root project.  This will build a zip file in the distribution directory containing
-`javametrics-agent.jar`, `javametrics-web.war` and a `lib/` directory with the `asm*.jar` files.
 
 ## Source code
 The source code for Application Metrics for Java is available in the [Javametrics Github project](http://github.com/RuntimeTools/javametrics).

--- a/javaagent/src/main/java/com/ibm/javametrics/dataproviders/DataProviderManager.java
+++ b/javaagent/src/main/java/com/ibm/javametrics/dataproviders/DataProviderManager.java
@@ -82,7 +82,7 @@ public class DataProviderManager {
             message.append(timeStamp);
             message.append("\", \"gcTime\": \"");
             message.append(gcTime);
-            message.append("\"}}");
+            message.append("\"}");
             Javametrics.getInstance().sendJSON(GC_TOPIC, message.toString());
         }
     }
@@ -99,7 +99,7 @@ public class DataProviderManager {
             message.append(system);
             message.append("\", \"process\": \"");
             message.append(process);
-            message.append("\"}}");
+            message.append("\"}");
             Javametrics.getInstance().sendJSON(CPU_TOPIC, message.toString());
         }
     }
@@ -119,7 +119,7 @@ public class DataProviderManager {
             message.append(usedHeap);
             message.append("\", \"usedNative\": \"");
             message.append(usedNative);
-            message.append("\"}}");
+            message.append("\"}");
             Javametrics.getInstance().sendJSON(MEMORYPOOLS_TOPIC, message.toString());
         }
     }

--- a/javaagent/src/main/java/com/ibm/javametrics/instrument/HttpData.java
+++ b/javaagent/src/main/java/com/ibm/javametrics/instrument/HttpData.java
@@ -144,7 +144,7 @@ public class HttpData {
         sb.append('\"');
         sb.append(",\"status\":");
         sb.append(status);
-        sb.append("\",\"contentType\":\"");
+        sb.append(",\"contentType\":\"");
         sb.append(contentType);
         sb.append("\",");
         sb.append(getHeaders());

--- a/javaagent/src/main/java/com/ibm/javametrics/instrument/HttpData.java
+++ b/javaagent/src/main/java/com/ibm/javametrics/instrument/HttpData.java
@@ -27,6 +27,7 @@ public class HttpData {
 
     long requestTime = 0;
     long duration = 0;
+    int status = 0;
     String url = null;
     String method = null;
     String contentType = null;
@@ -47,6 +48,14 @@ public class HttpData {
 
     public void setDuration(long duration) {
         this.duration = duration;
+    }
+
+    int getStatus() {
+        return status;
+    }
+
+    void setStatus(int status) {
+        this.status = status;
     }
 
     public String getUrl() {
@@ -132,6 +141,9 @@ public class HttpData {
         sb.append(url);
         sb.append("\",\"method\":\"");
         sb.append(method);
+        sb.append('\"');
+        sb.append(",\"status\":");
+        sb.append(status);
         sb.append("\",\"contentType\":\"");
         sb.append(contentType);
         sb.append("\",");

--- a/javaagent/src/main/java/com/ibm/javametrics/instrument/ServletCallback.java
+++ b/javaagent/src/main/java/com/ibm/javametrics/instrument/ServletCallback.java
@@ -31,6 +31,7 @@ public class ServletCallback {
     private static final String HTTP_TOPIC = "http";
     private static final String GET_REQUEST_URL = "getRequestURL";
     private static final String GET_METHOD = "getMethod";
+    private static final String GET_STATUS = "getStatus";
     private static final String GET_CONTENT_TYPE = "getContentType";
     private static final String GET_HEADER_NAMES = "getHeaderNames";
     private static final String GET_HEADER = "getHeader";
@@ -134,10 +135,13 @@ public class ServletCallback {
             Method getRequestURL = reqClass.getMethod(GET_REQUEST_URL);
             data.setUrl(((StringBuffer) getRequestURL.invoke(request)).toString());
 
-            if (detailed ) {
-                Method getMethod = reqClass.getMethod(GET_METHOD);
-                data.setMethod((String) getMethod.invoke(request));
+            Method getMethod = reqClass.getMethod(GET_METHOD);
+            data.setMethod((String) getMethod.invoke(request));
 
+            Method getStatus = respClass.getMethod(GET_STATUS);
+            data.setStatus((Integer) getStatus.invoke(response));
+
+            if (detailed) {
                 Method getContentType = respClass.getMethod(GET_CONTENT_TYPE);
                 data.setContentType((String) getContentType.invoke(response));
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,5 +8,6 @@
   <modules>
     <module>javaagent</module>
     <module>dashboard</module>
+    <module>prometheus</module>
   </modules>
 </project>

--- a/prometheus/pom.xml
+++ b/prometheus/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>javametrics-prometheus</artifactId>
   <packaging>war</packaging>
-  <name>metrics</name>
+  <name>prometheus</name>
   <description>Application Metrics for Java on a prometheus /metrics endpoint.</description>
   <url>https://github.com/RuntimeTools/javametrics</url>
 

--- a/prometheus/pom.xml
+++ b/prometheus/pom.xml
@@ -1,0 +1,203 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <groupId>com.ibm.runtimetools</groupId>
+  <version>1.0.1</version>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>javametrics-prometheus</artifactId>
+  <packaging>war</packaging>
+  <name>metrics</name>
+  <description>Application Metrics for Java on a prometheus /metrics endpoint.</description>
+  <url>https://github.com/RuntimeTools/javametrics</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+  </properties>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git://github.com/runtimetools/javametrics.git</connection>
+    <developerConnection>scm:git:ssh://github.com/runtimetools/javametrics.git</developerConnection>
+    <url>http://github.com/runtimetools/javametrics.git/tree/master</url>
+  </scm>
+
+  <developers>
+    <developer>
+      <name>Toby Corbin</name>
+      <email>corbint@uk.ibm.com</email>
+      <organization>IBM</organization>
+      <organizationUrl>http://www.ibm.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+  </distributionManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.ibm.runtimetools</groupId>
+      <artifactId>javametrics-agent</artifactId>
+      <version>1.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.json</groupId>
+      <artifactId>javax.json-api</artifactId>
+      <version>1.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/javax.servlet/javax.servlet-api -->
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+    <!-- The client -->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>0.0.26</version>
+    </dependency>
+    <!-- Hotspot JVM metrics -->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
+      <version>0.0.26</version>
+    </dependency>
+    <!-- Exposition servlet -->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <version>0.0.26</version>
+    </dependency>
+    <!-- Pushgateway exposition -->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_pushgateway</artifactId>
+      <version>0.0.26</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.7.201606060606</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <!-- <packagingExcludes>%regex[WEB-INF/lib/*.*]</packagingExcludes>-->
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <phase>deploy</phase>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-gpg-plugin</artifactId>
+        <version>1.5</version>
+        <executions>
+          <execution>
+            <id>sign-artifacts</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>sign</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <version>1.6.7</version>
+        <extensions>true</extensions>
+        <configuration>
+          <serverId>ossrh</serverId>
+          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.6.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+          <compilerArgs>
+            <arg>-Xlint:all</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-eclipse-plugin</artifactId>
+        <version>2.10</version>
+        <configuration>
+          <projectNameTemplate>
+            [artifactId]-[version]
+          </projectNameTemplate>
+          <wtpapplicationxml>true</wtpapplicationxml>
+          <wtpversion>2.0</wtpversion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/prometheus/src/main/java/com/ibm/javametrics/prometheus/Metrics.java
+++ b/prometheus/src/main/java/com/ibm/javametrics/prometheus/Metrics.java
@@ -1,0 +1,156 @@
+package com.ibm.javametrics.prometheus;
+
+import java.io.StringReader;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonReader;
+import javax.json.JsonString;
+
+import com.ibm.javametrics.Javametrics;
+import com.ibm.javametrics.JavametricsListener;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Summary;
+
+public class Metrics {
+
+    private Counter requests = Counter.build().name("incrementing_count").help("A test count.").register();
+
+    // Gauges for cpu usage.
+    private Gauge os_cpu_used_ratio = Gauge.build().name("os_cpu_used_ratio")
+            .help("The ratio of the systems CPU that is currently used (values are 0-1)").register();
+    private Gauge process_cpu_used_ratio = Gauge.build().name("process_cpu_used_ratio")
+            .help("The ratio of the process CPU that is currently used (values are 0-1)").register();
+
+    private Summary http_request_duration_microseconds = Summary.build()
+            .quantile(0.5, 0.05)
+            .quantile(0.9, 0.01)
+            .quantile(0.99, 0.001)
+            .name("http_request_duration_microseconds")
+            .help("The HTTP request latencies in microseconds.")
+            .labelNames("handler").register();
+
+    // Gauges for memory usage - TODO as native memory usage is not in
+    // JavaMetrics.
+    /*
+    static final Gauge os_resident_memory_bytes = Gauge.build().name("os_resident_memory_bytes")
+            .help("OS memory size in bytes.").register();
+    static final Gauge process_resident_memory_bytes = Gauge.build().name("process_resident_memory_bytes")
+            .help("Resident memory size in bytes.").register();
+    static final Gauge process_virtual_memory_bytes = Gauge.build().name("process_virtual_memory_bytes")
+            .help("Virtual memory size in bytes.").register();
+    */
+
+    // HTTP Counters
+    private Counter http_requests_total = Counter.build().labelNames("code", "handler", "method")
+            .name("http_requests_total").help("Total number of HTTP requests made.").register();
+
+    private JavametricsListener listener = this::parseData;
+
+    public Metrics() {
+
+        // Connect to javametrics
+        Javametrics.getInstance().addListener(listener);
+    }
+
+    public void deRegister() {
+        Javametrics.getInstance().removeListener(listener);
+    }
+
+    private void parseData(String pluginName, String jsonData) {
+        if (pluginName.equals("api")) {
+            List<String> split = splitIntoJSONObjects(jsonData);
+            for (Iterator<String> iterator = split.iterator(); iterator.hasNext();) {
+                String jsonStr = iterator.next();
+                JsonReader jsonReader = Json.createReader(new StringReader(jsonStr));
+                try {
+                    JsonObject jsonObject = jsonReader.readObject();
+                    String topicName = jsonObject.getString("topic", null);
+                    switch (topicName) {
+                    case "http":
+                        handleHttpTopic(jsonObject.getJsonObject("payload"));
+                        break;
+                    case "cpu":
+                        JsonString system = jsonObject.getJsonObject("payload").getJsonString("system");
+                        JsonString process = jsonObject.getJsonObject("payload").getJsonString("process");
+
+                        os_cpu_used_ratio.set(Double.valueOf(system.getString()));
+                        process_cpu_used_ratio.set(Double.valueOf(process.getString()));
+                        break;
+                    default:
+                        break;
+                    }
+                } catch (JsonException je) {
+                    // Skip this object, log the exception and keep trying with
+                    // the rest of the list
+                    je.printStackTrace();
+                }
+            }
+        }
+    }
+
+    private void handleHttpTopic(JsonObject jsonObject) {
+        String urlStr = jsonObject.getJsonString("url").getString();
+        String method = jsonObject.getJsonString("method").getString();
+        String status = jsonObject.getJsonNumber("status").toString();
+        long duration = jsonObject.getJsonNumber("duration").longValue();
+        // duration needs to be in microseconds.
+        duration *= 1000;
+
+        try {
+            URL url = new URL(urlStr);
+            String handler = url.getPath();
+
+            http_requests_total.labels(status, handler, method).inc();
+            http_request_duration_microseconds.labels(handler).observe((double) duration);
+        } catch (MalformedURLException e) {
+            // Our URLs came from Liberty, they should be valid.
+            // e.printStackTrace();
+        }
+    }
+
+    private static List<String> splitIntoJSONObjects(String data) {
+        List<String> strings = new ArrayList<String>();
+        int index = 0;
+        // Find first opening bracket
+        while (index < data.length() && data.charAt(index) != '{') {
+            index++;
+        }
+        int closingBracket = index + 1;
+        int bracketCounter = 1;
+        while (index < data.length() - 1 && closingBracket < data.length()) {
+            // Find the matching bracket for the bracket at location 'index'
+            boolean found = false;
+            if (data.charAt(closingBracket) == '{') {
+                bracketCounter++;
+            } else if (data.charAt(closingBracket) == '}') {
+                bracketCounter--;
+                if (bracketCounter == 0) {
+                    // found matching bracket
+                    found = true;
+                }
+            }
+            if (found) {
+                strings.add(data.substring(index, closingBracket + 1));
+                index = closingBracket + 1;
+                // Find next opening bracket and reset counters
+                while (index < data.length() && data.charAt(index) != '{') {
+                    index++;
+                }
+                closingBracket = index + 1;
+                bracketCounter = 1;
+            } else {
+                closingBracket++;
+            }
+        }
+        return strings;
+    }
+}

--- a/prometheus/src/main/java/com/ibm/javametrics/prometheus/MetricsContextListener.java
+++ b/prometheus/src/main/java/com/ibm/javametrics/prometheus/MetricsContextListener.java
@@ -1,0 +1,34 @@
+package com.ibm.javametrics.prometheus;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.annotation.WebListener;
+
+import io.prometheus.client.exporter.MetricsServlet;
+
+@WebListener
+public class MetricsContextListener implements ServletContextListener {
+
+    private Metrics metrics;
+
+    @Override
+    public void contextDestroyed(ServletContextEvent event) {
+        metrics.deRegister();
+    }
+
+    /* This should initialise the prometheus metrics when the
+     * server starts up instead of the first time /metrics is
+     * queried.
+     */
+    @Override
+    public void contextInitialized(ServletContextEvent event) {
+        // Uncomment the next line to enable the default hotspot events.
+        // DefaultExports.initialize();
+
+        metrics = new Metrics();
+        ServletContext context = event.getServletContext();
+        context.addServlet("Metrics", new MetricsServlet()).addMapping("");
+    }
+
+}

--- a/prometheus/src/main/webapp/WEB-INF/ibm-web-ext.xml
+++ b/prometheus/src/main/webapp/WEB-INF/ibm-web-ext.xml
@@ -1,0 +1,8 @@
+<web-ext
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://websphere.ibm.com/xml/ns/javaee"
+  xsi:schemaLocation="http://websphere.ibm.com/xml/ns/javaee http://websphere.ibm.com/xml/ns/javaee/ibm-web-ext_1_0.xsd"
+  version="1.0"
+>
+  <context-root uri="/metrics"/>
+</web-ext>

--- a/prometheus/src/main/webapp/WEB-INF/web.xml
+++ b/prometheus/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app id="WebApp_ID" version="3.1" xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd">
+	<display-name>javametrics-prometheus</display-name>
+	<welcome-file-list>
+		<welcome-file>index.html</welcome-file>
+		<welcome-file>index.htm</welcome-file>
+		<welcome-file>index.jsp</welcome-file>
+		<welcome-file>default.html</welcome-file>
+		<welcome-file>default.htm</welcome-file>
+		<welcome-file>default.jsp</welcome-file>
+	</welcome-file-list>
+</web-app>


### PR DESCRIPTION
This adds a /metrics endpoint displaying data from the javametrics agent.
It uses Maven to pull in the official prometheus Java API from:
https://github.com/prometheus/client_java
and uses it to supply `Counter`, `Gauge` and `Summary` object and output via the `MetricsServlet` class.
It listens to `http` and `cpu` events from Javametrics to supply data to the prometheus classes.