### PR TITLE
Add the method to the data we return to the dashboard and the REST API

### DIFF
--- a/javaagent/src/main/java/com/ibm/javametrics/analysis/MetricsContext.java
+++ b/javaagent/src/main/java/com/ibm/javametrics/analysis/MetricsContext.java
@@ -57,9 +57,9 @@ public class MetricsContext {
         httpData.clear();
     }
 
-    public void aggregateHttp(long timeStamp, long duration, String url) {
+    public void aggregateHttp(long timeStamp, long duration, String url, String method) {
         if (timeStamp >= startTime) {
-            httpData.aggregate(timeStamp, duration, url);
+            httpData.aggregate(timeStamp, duration, url, method);
         }
     }
 

--- a/javaagent/src/main/java/com/ibm/javametrics/analysis/MetricsData.java
+++ b/javaagent/src/main/java/com/ibm/javametrics/analysis/MetricsData.java
@@ -15,6 +15,7 @@
  ******************************************************************************/
 package com.ibm.javametrics.analysis;
 
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -36,7 +37,7 @@ public class MetricsData {
     long usedHeapAfterGCPeak;
     long usedNativePeak;
 
-    Map<String, HttpUrlData> urlData;
+    Collection<HttpUrlData> urlData;
 
     public double getGcTime() {
         return gcTime;
@@ -74,7 +75,7 @@ public class MetricsData {
         return usedNativePeak;
     }
 
-    public Map<String, HttpUrlData> getUrlData() {
+    public Collection<HttpUrlData> getUrlData() {
         return urlData;
     }
 
@@ -106,15 +107,14 @@ public class MetricsData {
         metricsJson.append(getUsedNativePeak());
 
         metricsJson.append("},\"httpUrls\":[");
-        Iterator<Entry<String, HttpUrlData>> it = getUrlData().entrySet().iterator();
+        Iterator<HttpUrlData> it = getUrlData().iterator();
         while (it.hasNext()) {
-            Entry<String, HttpUrlData> pair = it.next();
+            HttpUrlData hud = it.next();
             metricsJson.append("{\"url\":\"");
-            metricsJson.append(pair.getKey());
-            HttpUrlData hud = pair.getValue();
-            metricsJson.append("\",\"hits\":");
-            metricsJson.append(hud.getHits());
-            metricsJson.append(",\"averageResponseTime\":");
+            metricsJson.append(hud.getUrl());
+            metricsJson.append("\",\"method\":\"");
+            metricsJson.append(hud.getMethod());
+            metricsJson.append("\",\"averageResponseTime\":");
             metricsJson.append(hud.getAverageResponseTime());
             metricsJson.append(",\"longestResponseTime\":");
             metricsJson.append(hud.getLongestResponseTime());

--- a/javaagent/src/main/java/com/ibm/javametrics/analysis/MetricsProcessor.java
+++ b/javaagent/src/main/java/com/ibm/javametrics/analysis/MetricsProcessor.java
@@ -69,7 +69,7 @@ public class MetricsProcessor extends ApiDataListener {
     // HTTP payload:
     // "duration":150,"url":"http://blah/example","method":"GET","status":200,"contentType":"null","header":{},"requestHeader":{}
     final static private Pattern httpPayload = Pattern
-            .compile("\\{\"time\":([0-9]*),\"duration\":([0-9]*),\"url\":\"(.*)\",\"method\":\".*");
+          .compile("\\{\"time\":([0-9]*),\"duration\":([0-9]*),\"url\":\"(.*)\",\"method\":\"(.*)\",\"status\".*");
 
     @Override
     public void processData(List<String> jsonData) {
@@ -172,14 +172,16 @@ public class MetricsProcessor extends ApiDataListener {
         long timeStamp = 0;
         long duration;
         String url;
-        if ((matcher.find()) && (matcher.groupCount() == 3)) {
+        String method;
+        if ((matcher.find()) && (matcher.groupCount() == 4)) {
             timeStamp = Long.parseLong(matcher.group(1));
             duration = Long.parseLong(matcher.group(2));
             url = matcher.group(3);
+            method = matcher.group(4);
             Iterator<Entry<Integer, MetricsContext>> it = metricsContexts.entrySet().iterator();
             while (it.hasNext()) {
                 Entry<Integer, MetricsContext> pair = it.next();
-                pair.getValue().aggregateHttp(timeStamp, duration, url);
+                pair.getValue().aggregateHttp(timeStamp, duration, url, method);
             }
         }
     }

--- a/javaagent/src/test/java/com/ibm/javametrics/analysis/MetricsProcessorTest.java
+++ b/javaagent/src/test/java/com/ibm/javametrics/analysis/MetricsProcessorTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -139,17 +140,23 @@ public class MetricsProcessorTest {
         
         md = mp.getMetricsData(contextId);
         assertNotNull("Added context should exist", md);
-        Map<String, HttpUrlData> urlData = md.getUrlData();
+        Collection<HttpUrlData> urlData = md.getUrlData();
         assertEquals(0, urlData.size());
         
         mp.removeContext(contextId);
     }
     
     private void checkUrlData(MetricsData md) {
-        Map<String, HttpUrlData> urlData = md.getUrlData();
+        Collection<HttpUrlData> urlData = md.getUrlData();
         assertEquals(3, urlData.size());
+
+        HttpUrlData hud = null;
+        for (HttpUrlData d : urlData) {
+            if ("http://localhost:9080/testy/v1/example".equals(d.getUrl())) {
+                hud = d;
+            }
+        }
         
-        HttpUrlData hud = urlData.get("http://localhost:9080/testy/v1/example");
         assertNotNull("Missing url data for http://localhost:9080/testy/v1/example", hud);
         assertEquals(2, hud.getHits());
         assertEquals(75, hud.getAverageResponseTime(), 0);
@@ -230,12 +237,12 @@ public class MetricsProcessorTest {
         System.out.println("gcTime:" + summary.getGcTime());
         System.out.println("usedHeapAfterGCPeak:" + summary.getUsedHeapAfterGCPeak() + " usedNativePeak:"
                 + summary.getUsedNativePeak());
-        Iterator<Entry<String, HttpUrlData>> it = summary.getUrlData().entrySet().iterator();
+        Iterator<HttpUrlData> it = summary.getUrlData().iterator();
         while (it.hasNext()) {
-            Entry<String, HttpUrlData> pair = it.next();
-            System.out.println(pair.getKey() + " hits:" + pair.getValue().getHits() + " average:"
-                    + pair.getValue().getAverageResponseTime() + " longest:"
-                    + pair.getValue().getLongestResponseTime());
+            HttpUrlData data = it.next();
+            System.out.println(data.getUrl() + " hits:" + data.getHits() + " average:"
+                    + data.getAverageResponseTime() + " longest:"
+                    + data.getLongestResponseTime());
         }
     }
 }

--- a/javaagent/src/test/java/com/ibm/javametrics/client/HttpDataAggregatorTest.java
+++ b/javaagent/src/test/java/com/ibm/javametrics/client/HttpDataAggregatorTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Map;
+import java.util.Collection;
 
 import org.junit.Test;
 
@@ -38,49 +38,55 @@ public class HttpDataAggregatorTest {
     public void testAgregation() {
         
         // Validate initial values
-        checkValues(0, 0, 0, 0, "");
+        checkValues(0, 0, 0, 0, "", "");
 
         long time = System.currentTimeMillis();      
-        aggregator.aggregate(time-300, 500, "myurl-1");  
-        aggregator.aggregate(time-400, 200, "myurl-2");  
-        aggregator.aggregate(time+666, 300, "myurl-1");  
-        aggregator.aggregate(time, 600, "myurl-2");  // Longest
-        aggregator.aggregate(time-222, 100, "myurl-1");
+        aggregator.aggregate(time-300, 500, "myurl-1", "GET");  
+        aggregator.aggregate(time-400, 200, "myurl-2", "PUT");  
+        aggregator.aggregate(time+666, 300, "myurl-1", "GET");  
+        aggregator.aggregate(time, 600, "myurl-2", "PUT");  // Longest
+        aggregator.aggregate(time-222, 100, "myurl-1", "GET");
         
-        checkValues(time, 340, 5, 600, "myurl-2");     
-        checkUrlData("myurl-1", 3, 300, 500);
-        checkUrlData("myurl-2", 2, 400, 600);
+        checkValues(time, 340, 5, 600, "myurl-2", "PUT");     
+        checkUrlData("myurl-1", 3, 300, 500, "GET");
+        checkUrlData("myurl-2", 2, 400, 600, "PUT");
    
         // resetSummaryData should only clear summary and not urlData
         aggregator.resetSummaryData();
-        checkValues(0, 0, 0, 0, "");
-        checkUrlData("myurl-1", 3, 300, 500);
-        checkUrlData("myurl-2", 2, 400, 600);
+        checkValues(0, 0, 0, 0, "", "");
+        checkUrlData("myurl-1", 3, 300, 500, "GET");
+        checkUrlData("myurl-2", 2, 400, 600, "PUT");
         
-        aggregator.aggregate(time-300, 500, "myurl-1");  
-        aggregator.aggregate(time-400, 200, "myurl-2");  
-        aggregator.aggregate(time+666, 300, "myurl-1");  
-        aggregator.aggregate(time, 600, "myurl-2");  
-        aggregator.aggregate(time-222, 100, "myurl-1");  
+        aggregator.aggregate(time-300, 500, "myurl-1", "GET");  
+        aggregator.aggregate(time-400, 200, "myurl-2", "POST");  
+        aggregator.aggregate(time+666, 300, "myurl-1", "GET");  
+        aggregator.aggregate(time, 600, "myurl-2", "POST");  
+        aggregator.aggregate(time-222, 100, "myurl-1", "GET");  
         
         // clear() should reset everything
         aggregator.clear();
-        checkValues(0, 0, 0, 0, "");
+        checkValues(0, 0, 0, 0, "", "");
         assertTrue("UrlData should be empty", aggregator.getUrlData().isEmpty());     
     }
 
-    private void checkValues(long time, double average, long total, long longest, String url) {
+    private void checkValues(long time, double average, long total, long longest, String url, String method) {
 
         assertEquals("time value incorrect", time, aggregator.getTime());
         assertEquals("totalHits value incorrect", total, aggregator.getTotalHits());
         assertEquals("average value incorrect", average, aggregator.getAverage(), 0);
         assertEquals("longest value incorrect", longest, aggregator.getLongest());
-        assertEquals("url value incorrect", url, aggregator.getUrl());
+        assertEquals("url value incorrect", url, aggregator.getLongestUrl());
+        assertEquals("method value incorrect", method, aggregator.getLongestMethod());
     }
     
-    private void checkUrlData(String url, int hits, long average, long longest) {
-        Map<String, HttpUrlData> urlData = aggregator.getUrlData();
-        HttpUrlData httpData = urlData.get(url);
+    private void checkUrlData(String url, int hits, long average, long longest, String method) {
+        Collection<HttpUrlData> urlData = aggregator.getUrlData();
+        HttpUrlData httpData = null;
+        for (HttpUrlData d : urlData) {
+            if (url.equals(d.getUrl())) {
+                httpData = d;
+            }
+        }
         assertNotNull("Expecting http data for url: " +  url, httpData);
         assertEquals("Incorrect number of hits for url: " +  url, hits, httpData.getHits());
         assertEquals("Incorrect average response time for url: " +  url, average, httpData.getAverageResponseTime(), 0);

--- a/spring/src/main/java/com/ibm/javametrics/web/DataHandler.java
+++ b/spring/src/main/java/com/ibm/javametrics/web/DataHandler.java
@@ -100,9 +100,10 @@ public class DataHandler extends ApiDataListener {
                         long requestTime = payload.getJsonNumber("time").longValue();
                         long requestDuration = payload.getJsonNumber("duration").longValue();
                         String requestUrl = payload.getString("url", "");
+                        String requestMethod = payload.getString("method", "");
 
                         synchronized (aggregateHttpData) {
-                            aggregateHttpData.aggregate(requestTime, requestDuration, requestUrl);
+                            aggregateHttpData.aggregate(requestTime, requestDuration, requestUrl, requestMethod);
                         }
                     } else {
                         emit(jsonObject.toString());
@@ -123,6 +124,7 @@ public class DataHandler extends ApiDataListener {
         long longest;
         double average;
         String url;
+        String method;
         StringBuilder httpUrlData;
         StringBuilder httpData;
 
@@ -131,7 +133,8 @@ public class DataHandler extends ApiDataListener {
             total = aggregateHttpData.getTotalHits();
             longest = aggregateHttpData.getLongest();
             average = aggregateHttpData.getAverage();
-            url = aggregateHttpData.getUrl();
+            url = aggregateHttpData.getLongestUrl();
+            method = aggregateHttpData.getLongestMethod();
 
             if (total == 0) {
                 time = System.currentTimeMillis();
@@ -149,22 +152,26 @@ public class DataHandler extends ApiDataListener {
             httpData.append(average);
             httpData.append(",\"url\":\"");
             httpData.append(url);
+            httpData.append("\",\"method\":\"");
+            httpData.append(method);
             httpData.append("\"}}");
 
             // emit JSON String representing HTTP request data by URL in the
             // format expected by the javascript
             httpUrlData = new StringBuilder("{\"topic\":\"httpURLs\",\"payload\":[");
-            Iterator<Entry<String, HttpUrlData>> it = aggregateHttpData.getUrlData().entrySet().iterator();
+            Iterator<HttpUrlData> it = aggregateHttpData.getUrlData().iterator();
             while (it.hasNext()) {
-                Entry<String, HttpUrlData> pair = it.next();
+                HttpUrlData hud = it.next();
                 httpUrlData.append("{\"url\":\"");
-                httpUrlData.append(pair.getKey());
+                httpUrlData.append(hud.getMethod());
+                httpUrlData.append(" ");
+                httpUrlData.append(hud.getUrl());
                 httpUrlData.append("\",\"hits\":");
-                httpUrlData.append(pair.getValue().getHits());
+                httpUrlData.append(hud.getHits());
                 httpUrlData.append(",\"longestResponseTime\":");
-                httpUrlData.append(pair.getValue().getLongestResponseTime());
+                httpUrlData.append(hud.getLongestResponseTime());
                 httpUrlData.append(",\"averageResponseTime\":");
-                httpUrlData.append(pair.getValue().getAverageResponseTime());
+                httpUrlData.append(hud.getAverageResponseTime());
                 httpUrlData.append('}');
                 if (it.hasNext()) {
                     httpUrlData.append(',');


### PR DESCRIPTION
This adds the http method to the dashboard and the REST API.
This is similar to the change that went into appmetrics for the summary table:
https://github.com/RuntimeTools/appmetrics-dash/pull/153
and the REST API:
https://github.com/RuntimeTools/appmetrics-dash/pull/155

![image](https://user-images.githubusercontent.com/11979939/43005940-3a67839c-8c2c-11e8-971b-b646b9da7701.png)
