### PR TITLE
bump version to 1.8.0 for release

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ Javametrics requires a Java option to be set in order to load the agent.  A [jvm
 
 ```
 # Load Javametrics Java agent
--javaagent:<path_to_javametrics_agent_dir>/javametrics-agent-1.7.0.jar
+-javaagent:<path_to_javametrics_agent_dir>/javametrics-agent-1.8.0.jar
 ```
 If you have built the agent locally, your path_to_javametrics_agent_dir will need to point to your clone of javametrics.
 e.g.
 ```
--javaagent:<path_to_git_home>/javametrics/javaagent/target/javametrics-agent-1.7.0.jar
+-javaagent:<path_to_git_home>/javametrics/javaagent/target/javametrics-agent-1.8.0.jar
 ```
 * NOTE, if you move the javametrics-agent to another directory you need to make sure you take the asm folder with it.  The asm folder is required for the agent to run as it contains files that the agent needs
 
@@ -129,12 +129,12 @@ You also need to add the following dependencies to your pom.xml:
 <dependency>
     <groupId>com.ibm.runtimetools</groupId>
     <artifactId>javametrics-spring</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
 </dependency>
 <dependency>
     <groupId>com.ibm.runtimetools</groupId>
     <artifactId>javametrics-agent</artifactId>
-    <version>1.7.0</version>
+    <version>1.8.0</version>
 </dependency>
 <dependency>
     <groupId>org.glassfish</groupId>
@@ -170,4 +170,4 @@ This project is released under an Apache 2.0 open source license.
 This project uses a semver-parsable X.0.Z version number for releases, where X is incremented for breaking changes to the public API described in this document and Z is incremented for bug fixes **and** for non-breaking changes to the public API that provide new function.
 
 ## Version
-1.7.0
+1.8.0

--- a/codewind-spring/pom.xml
+++ b/codewind-spring/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.ibm.runtimetools</groupId>
 	<artifactId>javametrics-codewind-spring</artifactId>
-	<version>1.7.0</version>
+	<version>1.8.0</version>
 	<packaging>jar</packaging>
 
 	<name>javametrics-codewind-spring</name>
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>com.ibm.runtimetools</groupId>
 			<artifactId>javametrics-agent</artifactId>
-			<version>1.7.0</version>
+			<version>1.8.0</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/codewind/pom.xml
+++ b/codewind/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <groupId>com.ibm.runtimetools</groupId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>javametrics-codewind</artifactId>
   <packaging>war</packaging>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.ibm.runtimetools</groupId>
       <artifactId>javametrics-agent</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <groupId>com.ibm.runtimetools</groupId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>javametrics-dash</artifactId>
   <packaging>war</packaging>
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>com.ibm.runtimetools</groupId>
       <artifactId>javametrics-agent</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/javaagent/pom.xml
+++ b/javaagent/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <groupId>com.ibm.runtimetools</groupId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>javametrics-agent</artifactId>
   <name>javaagent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.ibm.runtimetools</groupId>
   <artifactId>javametrics</artifactId>
   <packaging>pom</packaging>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <modules>
     <module>javaagent</module>
     <module>codewind</module>

--- a/prometheus/pom.xml
+++ b/prometheus/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <groupId>com.ibm.runtimetools</groupId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>javametrics-prometheus</artifactId>
   <packaging>war</packaging>
@@ -51,7 +51,7 @@
     <dependency>
       <groupId>com.ibm.runtimetools</groupId>
       <artifactId>javametrics-agent</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <groupId>com.ibm.runtimetools</groupId>
-  <version>1.7.0</version>
+  <version>1.8.0</version>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>javametrics-rest</artifactId>
   <packaging>war</packaging>
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>com.ibm.runtimetools</groupId>
       <artifactId>javametrics-agent</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.ibm.runtimetools</groupId>
 	<artifactId>javametrics-spring</artifactId>
-	<version>1.7.0</version>
+	<version>1.8.0</version>
 	<packaging>jar</packaging>
 
 	<name>javametrics-spring</name>
@@ -58,7 +58,7 @@
 		<dependency>
 			<groupId>com.ibm.runtimetools</groupId>
 			<artifactId>javametrics-agent</artifactId>
-			<version>1.7.0</version>
+			<version>1.8.0</version>
 			<scope>provided</scope>
 		</dependency>
 


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

Release version 1.8.0 of javametrics.  This release contains a fix for the gc graph to prevent it plotting outside the bounds of the graph

```
[INFO] Building javametrics 1.8.0
[INFO] ------------------------------------------------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ javametrics ---
[INFO] Deleting /Users/tobes/workspaces/git/javametrics/target
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] javaagent .......................................... SUCCESS [ 45.895 s]
[INFO] codewind ........................................... SUCCESS [  0.882 s]
[INFO] dashboard .......................................... SUCCESS [  0.373 s]
[INFO] prometheus ......................................... SUCCESS [  0.186 s]
[INFO] javametrics-spring ................................. SUCCESS [  1.113 s]
[INFO] javametrics-codewind-spring ........................ SUCCESS [  0.212 s]
[INFO] rest ............................................... SUCCESS [  0.320 s]
[INFO] javametrics ........................................ SUCCESS [  0.035 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 49.679 s
[INFO] Finished at: 2020-03-03T09:19:41Z
[INFO] Final Memory: 43M/468M
[INFO] ------------------------------------------------------------------------
```